### PR TITLE
Add tests and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # ytplay
+
+A simple CLI tool that renders YouTube videos as ASCII art.
+
+## Running Tests
+
+Install the required dependencies and run `pytest` from the project root:
+
+```bash
+pip install -r requirements.txt  # install dependencies
+pytest
+```
+
+The tests are located in the `tests/` directory and cover basic functionality
+of the rendering and streaming managers.

--- a/VideoStreamManager.py
+++ b/VideoStreamManager.py
@@ -18,7 +18,12 @@ class VideoStreamManager:
             dict: A dictionary containing the stream URL
         """
         ytdl = yt_dlp.YoutubeDL(self._yt_dlp_opts)
-        video_info = ytdl.extract_info(video_url, download=False)
+        try:
+            video_info = ytdl.extract_info(video_url, download=False)
+        except Exception as exc:  # Catch broad exceptions from yt_dlp
+            raise ValueError(
+                f"Unable to fetch metadata for URL {video_url}: {exc}"
+            ) from exc
 
         return {"stream_url": video_info["url"]}
 
@@ -32,12 +37,20 @@ class VideoStreamManager:
             frame_callback (function): A function to process each video frame
         """
         cv2_capture = cv2.VideoCapture(stream_url)
+        if not cv2_capture.isOpened():
+            raise RuntimeError(f"Failed to open video stream: {stream_url}")
 
+        first_frame = True
         while True:
             ret, frame = cv2_capture.read()
             if not ret or frame is None:
+                if first_frame:
+                    raise RuntimeError(
+                        f"Failed to read video frames from stream: {stream_url}"
+                    )
                 break
 
+            first_frame = False
             frame_callback(frame)
 
         cv2_capture.release()

--- a/tests/test_rendering_manager.py
+++ b/tests/test_rendering_manager.py
@@ -1,0 +1,18 @@
+import numpy as np
+from RenderingManager import RenderingManager
+
+
+def test_convert_frame_to_ascii():
+    # Create a 2x2 BGR image with increasing brightness
+    frame = np.array(
+        [
+            [[0, 0, 0], [128, 128, 128]],
+            [[192, 192, 192], [255, 255, 255]],
+        ],
+        dtype=np.uint8,
+    )
+
+    manager = RenderingManager()
+    ascii_art = manager.convert_frame_to_ascii(frame, scale_factor=1.0, max_frame_width=0)
+
+    assert ascii_art == "@+\n: \n"

--- a/tests/test_video_stream_manager.py
+++ b/tests/test_video_stream_manager.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock, patch
+
+from VideoStreamManager import VideoStreamManager
+
+
+def test_get_video_metadata():
+    expected_stream = "http://test/stream"
+    with patch("yt_dlp.YoutubeDL") as MockYDL:
+        mock_instance = MockYDL.return_value
+        mock_instance.extract_info.return_value = {"url": expected_stream}
+
+        manager = VideoStreamManager()
+        metadata = manager.get_video_metadata("https://example.com/video")
+
+        mock_instance.extract_info.assert_called_once_with(
+            "https://example.com/video", download=False
+        )
+        assert metadata == {"stream_url": expected_stream}


### PR DESCRIPTION
## Summary
- add tests for the rendering and streaming managers
- handle common errors when capturing video or retrieving metadata
- document how to run tests in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_683ffcef6778832387ec13d3fc6133f5